### PR TITLE
Adicionar Dockerfile e docker-compose para configuração do ambiente Nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Usar a imagem base do Nginx
+FROM nginx:alpine
+
+# Definir o diretório de trabalho dentro do container
+WORKDIR /usr/share/nginx/html
+
+# Remover os arquivos padrão da pasta HTML do Nginx
+RUN rm -rf ./*
+
+# Copiar seus arquivos da pasta local para o diretório de trabalho no container
+COPY . /usr/share/nginx/html
+
+# Expor a porta 80 para servir a aplicação
+EXPOSE 80
+
+# Iniciar o Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,26 @@
 # Usar a imagem base do Nginx
 FROM nginx:alpine
 
+RUN apk add --no-cache avahi dbus avahi-tools
+
+RUN mkdir -p /var/run/dbus && \
+    mkdir -p /var/run/avahi-daemon
+
 # Definir o diretório de trabalho dentro do container
 WORKDIR /usr/share/nginx/html
-
-# Remover os arquivos padrão da pasta HTML do Nginx
 RUN rm -rf ./*
 
 # Copiar seus arquivos da pasta local para o diretório de trabalho no container
 COPY . /usr/share/nginx/html
+COPY ./docker-config/nginx.conf /etc/nginx/nginx.conf
+COPY ./docker-config/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 
-# Expor a porta 80 para servir a aplicação
-EXPOSE 80
+RUN rm -rf /etc/avahi/services/*
 
-# Iniciar o Nginx
-CMD ["nginx", "-g", "daemon off;"]
+EXPOSE 80 5353/udp
+
+COPY ./docker-config/start.sh /start.sh
+RUN chmod +x /start.sh
+
+#iniciar o container
+CMD ["/start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,13 @@ services:
       dockerfile: Dockerfile
     image: sphynx-web-img
     container_name: sphynx-web-container
+    hostname: sphynx.local
     working_dir: /app
     healthcheck:
       test: ["CMD", "lsof", "-t", "-i:3000"]
       timeout: 10s
       retries: 5
     ports:
-      - "8080:80"
+      - "57129:80"
     volumes:
       - .:/usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: sphynx-web-img
+    container_name: sphynx-web-container
+    working_dir: /app
+    healthcheck:
+      test: ["CMD", "lsof", "-t", "-i:3000"]
+      timeout: 10s
+      retries: 5
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/usr/share/nginx/html

--- a/docker-config/avahi-daemon.conf
+++ b/docker-config/avahi-daemon.conf
@@ -1,0 +1,13 @@
+[server]
+use-ipv4=yes
+use-ipv6=yes
+allow-interfaces=eth0
+
+[wide-area]
+enable-wide-area=no
+
+[publish]
+disable-publishing=no
+publish-addresses=yes
+publish-hinfo=yes
+publish-workstation=no

--- a/docker-config/nginx.conf
+++ b/docker-config/nginx.conf
@@ -1,0 +1,59 @@
+worker_processes  40;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    upstream web_servers {
+        server localhost:57129;
+        server 127.0.0.1:57129;
+    }
+
+    server {
+        listen 80;
+        listen 57129;
+
+        server_name sphynx.local;
+
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        location /dashboard {
+            try_files $uri $uri/ /pages/dashboard.html;
+        }
+
+        location /usuarios {
+            try_files $uri $uri/ /pages/usuarios.html;
+        }
+
+        location /locais {
+            try_files $uri $uri/ /pages/locais.html;
+        }
+
+        location /acessos {
+            try_files $uri $uri/ /pages/acessos.html;
+        }
+
+        location /grupos {
+            try_files $uri $uri/ /pages/grupos.html;
+        }
+
+        location /configuracoes {
+            try_files $uri $uri/ /pages/configuracoes.html;
+        }
+
+        error_log /var/log/nginx/error.log;
+        access_log /var/log/nginx/access.log;
+    }
+}

--- a/docker-config/start.sh
+++ b/docker-config/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+dbus-daemon --system --print-address
+
+avahi-daemon --no-drop-root &
+
+nginx -g "daemon off;"


### PR DESCRIPTION
## Descrição:
Este Pull Request adiciona a configuração necessária para o container Docker de um servidor Nginx, utilizando um `Dockerfile` e um arquivo `docker-compose.yml` para gerenciar a aplicação.

## Alterações principais:
1. **Dockerfile**:
   - Utiliza a imagem base do Nginx a partir de `nginx:alpine`.
   - Define o diretório de trabalho como `/usr/share/nginx/html`.
   - Remove os arquivos padrão da pasta HTML do Nginx.
   - Copia os arquivos locais para o diretório de trabalho dentro do container.
   - Exposição da porta 80 para servir a aplicação.
   - Comando para iniciar o Nginx com o daemon desativado.

2. **docker-compose.yml**:
   - Define o serviço `app` que constrói a imagem com base no Dockerfile.
   - Especifica a imagem como `sphynx-web-img` e o nome do container como `sphynx-web-container`.
   - Mapeia a porta `8080` local para a porta `80` do container.
   - Configura o volume para sincronizar o diretório atual com o diretório HTML do Nginx no container.
   - Adiciona um `healthcheck` que verifica se a porta `3000` está ativa.

## Teste:
Para testar a configuração, execute o comando a seguir:

```bash
docker-compose up --build
